### PR TITLE
Rename `onInit`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,15 +1,12 @@
 module.exports = function runPlugin(inputs) {
   if (!inputs.triggerAll) {
     return {
-      onInit: () => {
+      onPreBuild: () => {
         console.log(`triggerAll set to ${inputs.triggerAll}, no fun 🤷🏻‍♀️!`);
       },
     };
   } else {
     return {
-      onInit: () => {
-        console.log('onInit: I run before anything else 🐣');
-      },
       onPreBuild: ({ inputs: { keyword } }) => {
         console.log('onPreBuild: I run_before_ build commands are executed 🌤');
         console.log('I will only use the keyword input: ', keyword);


### PR DESCRIPTION
The `onInit` event handler has been renamed to `onPreBuild` since those two are currently identical. This PR renames this handler.